### PR TITLE
Fix documentation for sodium_pad

### DIFF
--- a/docs/padding.md
+++ b/docs/padding.md
@@ -11,7 +11,7 @@ Bindings for the padding API. [See the libsodium padding docs for more informati
 ``` js
 var paddedLength = sodium.sodium_pad(buf, unpaddedLength, blocksize)
 ```
-Pads `buf` with random data from index `unpaddedLength` up to closest multiple of `blocksize`.
+Pads `buf` with `0x80` followed by `0x00` bytes from index `unpaddedLength` up to closest multiple of `blocksize`.
 * `buf` must be a `buffer`
 * `unpaddedLength` must be an integer at most `buf.length`
 * `blocksize` must be an integer greater than 1, but at most `buf.length`


### PR DESCRIPTION
The documentation says that sodium_pad uses random data, but it actually
follows a simple algorithm where the first padded byte is `0x80` and the
rest are just `0x00`.

This replaces the incorrect documentation with a simple description of
the correct algorithm.

Reported-By: Christophe Diederichs <chris.d.itunes@gmail.com>
Link: https://github.com/sodium-friends/docs/issues/3