### PR TITLE
fix typo in Get Started code snippet

### DIFF
--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -36,7 +36,7 @@ console.log('Encrypted message:', ciphertext)
 
 var plainText = Buffer.alloc(ciphertext.length - sodium.crypto_secretbox_MACBYTES)
 
-if (!sodium.crypto_secretox_open_easy(plainText, ciphertext, nonce, key)) {
+if (!sodium.crypto_secretbox_open_easy(plainText, ciphertext, nonce, key)) {
     console.log('Decryption failed!')
 } else {
     console.log('Decrypted message:', plainText, '(' + plainText.toString() + ')')


### PR DESCRIPTION
This fixes a typo in the code snippet method name in **Get Started** section
```js
// before
if (!sodium.crypto_secretox_open_easy(...

// after
if (!sodium.crypto_secretbox_open_easy(...
```