### PR TITLE
Fix incorrect name function crypto_sign_seed25519_keypair in documentation

### DIFF
--- a/docs/signing.md
+++ b/docs/signing.md
@@ -16,10 +16,10 @@ Bindings for the crypto_sign API. [See the libsodium crypto_sign docs for more i
 * `crypto_box_SECRETKEYBYTES`
 
 ***
-## `crypto_sign_seed25519_keypair`
+## `crypto_sign_seed_keypair`
 ![sodium-native][node] ![sodium-javascript][js]
 ``` js
-sodium.crypto_sign_seed25519_keypair(pk, sk, seed)
+sodium.crypto_sign_seed_keypair(pk, sk, seed)
 ```
 Creates a new keypair based on a `seed`.
 * `pk` should be a `buffer` of length `crypto_sign_PUBLICKEYBYTES`


### PR DESCRIPTION
Original: https://github.com/sodium-friends/sodium-native/issues/155